### PR TITLE
LanguageToggle route change with test added

### DIFF
--- a/__tests__/components/atoms/LanguageToggle.test.js
+++ b/__tests__/components/atoms/LanguageToggle.test.js
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { toHaveNoViolations } from 'jest-axe'
+import { useRouter } from 'next/router'
+import LanguageToggle from '../../../components/atoms/LanguageToggle'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
+
+expect.extend(toHaveNoViolations)
+
+describe('LanguageToggle', () => {
+  it('renders Toggle', () => {
+    useRouter.mockImplementation(() => ({
+      asPath: '/',
+    }))
+
+    const toggleRender = render(<LanguageToggle />)
+    expect(render).toBeTruthy()
+  })
+})

--- a/components/atoms/LanguageToggle.js
+++ b/components/atoms/LanguageToggle.js
@@ -7,20 +7,14 @@ export default function LanguageToggle() {
   return (
     <div>
       <div className="hidden md:inline">
-        <Link
-          href={router.asPath}
-          locale={router.locale === 'en' ? 'fr' : 'en'}
-        >
+        <Link href={'/dashboard'} locale={router.locale === 'en' ? 'fr' : 'en'}>
           <a className="font-medium">
             {router.locale === 'en' ? 'Français' : 'English'}
           </a>
         </Link>
       </div>
       <div className="ml-7 md:hidden">
-        <Link
-          href={router.asPath}
-          locale={router.locale === 'en' ? 'fr' : 'en'}
-        >
+        <Link href={'/dashboard'} locale={router.locale === 'en' ? 'fr' : 'en'}>
           <a className="font-bold">{router.locale === 'en' ? 'FR' : 'EN'}</a>
         </Link>
       </div>


### PR DESCRIPTION
## [DC-958](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-958) (Jira Issue)

### Description

### List of proposed changes:
- Modified the route to route directly to `/dashboard`

### What to test for/How to test
- LanguageToggle renders with no issues

### Addtional Notes
