### PR TITLE
Possible Dockerfile workaround for build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ COPY --from=build /build/next.config.js ./
 COPY --from=build /build/package*.json ./
 COPY --from=build /build/.next ./.next
 COPY --from=build /build/public ./public
+# WORKAROUND - Copying the pages twice isn't really nice
+COPY --from=build /build/i18n.json ./i18n.json
+COPY --from=build /build/.next/server/pages ./pages
+
 RUN npm install next
 
 CMD npm run start


### PR DESCRIPTION
## [DC-1035](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-1035) (Jira Issue)

### Description

### List of proposed changes:
- Added two lines in the Dockerfile to copy over files that the `next-translate` package doesn't read properly when Dockerized

### What to test for/How to test
- Docker image builds with no errors

### Addtional Notes
- Workaround only for simulation, I think for MVP we can use a different/cleaner hook
